### PR TITLE
Enabling Retro Achevements and Band-Aid fixing UICommon Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ option(ENABLE_VR "Enables VR support via OpenXR (Windows D3D/Vulkan, Linux Vulka
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current game on Discord" OFF)
 option(USE_MGBA "Enables GBA controllers emulation using libmgba" OFF)
 option(ENABLE_AUTOUPDATE "Enables support for automatic updates" OFF)
-option(USE_RETRO_ACHIEVEMENTS "Enables integration with retroachievements.org" OFF)
+option(USE_RETRO_ACHIEVEMENTS "Enables integration with retroachievements.org" ON)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(uicommon
   UICommon.h
 )
 
+if (MSVC)
+  set_source_files_properties(UICommon.cpp PROPERTIES COMPILE_OPTIONS "/WX-")
+endif()
+
 target_link_libraries(uicommon
 PUBLIC
   common


### PR DESCRIPTION
Enabled Retro Achevements and Warnings aren't treated as errors for UICommon when using MSVC